### PR TITLE
Fixes to enable smoother installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# These are needed to run setup.py and pip
+# setuptools and wheel are needed for any of this to run. Cython, numpy,
+# and sphinx are specific dependencies for this setup.py
+[build-system]
+requires = ["setuptools>=50.0", "wheel", "Cython", "numpy", "sphinx"]

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
             'build_dir': (None, 'docs/_build'),
             'config_dir': (None, 'docs'),
             }},
+  install_requires=["numpy", "scipy", "astropy"],
   ext_modules=ext_modules)


### PR DESCRIPTION
We're installing Delight as part of an automated pipeline, and it can cause build issues because its dependencies are not declared.

This adds two changes:
- the pyproject.toml declares requirements that are needed to be able to import setup.py in the first place.
- the install_requires option in setup.py ensure that other dependencies are installed when building. 