### PR TITLE
add missing keyword to tests/parametersTest.cfg addresses #16

### DIFF
--- a/tests/parametersTest.cfg
+++ b/tests/parametersTest.cfg
@@ -16,6 +16,7 @@ directory: ./data/CWW_SEDs
 names: El_B2004a Sbc_B2004a Scd_B2004a SB3_B2004a Im_B2004a SB2_B2004a ssp_25Myr_z008 ssp_5Myr_z008
 p_t: 0.27 0.26 0.25 0.069 0.021 0.11 0.0061 0.0079
 p_z_t:0.23 0.39 0.33 0.31 1.1 0.34 1.2 0.14
+sed_fmt: sed
 lambdaRef: 4.5e3
 
 [Simulation]


### PR DESCRIPTION
add missing keyword to config so test script runs properly.